### PR TITLE
Revert "chore(docs): minor update to formatting of API link in README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Finch Java SDK is similar to the Finch Kotlin SDK but with minor differences
 
 ## Documentation
 
-The REST API documentation can be found on [developer.tryfinch.com](https://developer.tryfinch.com/).
+The REST API documentation can be found [in the Finch Documentation Center](https://developer.tryfinch.com/).
 
 ---
 


### PR DESCRIPTION
… (#249)"

This reverts commit 636c8cad8932ee636ad16fc96022ae0126dd8b03.

This preserves the custom wording this repo is using for linking to the API Documentation.